### PR TITLE
Adds dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
+
+# Ignore git directory.
+/.git/
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore all default key files.
+/config/master.key
+/config/credentials/*.key
+
+# Ignore all environment files.
+/.env*
+!/.env.example
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep
+
+# Ignore storage (uploaded files in development and any SQLite databases).
+/storage/*
+!/storage/.keep
+/tmp/storage/*
+!/tmp/storage/
+!/tmp/storage/.keep
+
+# Ignore assets.
+/node_modules/
+/app/assets/builds/*
+!/app/assets/builds/.keep
+/public/assets
+
+.irb_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+ARG RUBY_VERSION=3.1.2
+ARG NODE_VERSION=20.1.0
+
+FROM node:$NODE_VERSION-slim as node
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install
+
+FROM ruby:$RUBY_VERSION-slim as base
+
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -y build-essential locales libvips libpq-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+WORKDIR /app
+
+FROM base as gems
+
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler && bundle install --jobs 20 --retry 5
+
+FROM base as build
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+COPY . ./
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/share /usr/local/share
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
+COPY --from=node /opt /opt
+COPY --from=node /app/node_modules /app/node_modules
+COPY --from=gems /usr/local/bundle /usr/local/bundle
+
+EXPOSE 3000
+
+CMD ["bin/start"]

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: unset PORT && bin/rails server
+web: unset PORT && bin/rails server -p 3000 -b '0.0.0.0'
 js: yarn build --watch
 css: yarn build:css --watch

--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ rails new demo-turbo-chat --css=bootstrap --javascript=esbuild --database=postgr
 1.4.0
 
 ## How To Set Up Project
+### With docker (recommended)
++ `docker-compose build`
++ `docker-compose up`
++ visit http://localhost:3000
+### Local
 + Bundle Install
 + bin/setup to install dependencies
++ Set envars for `REDIS_URL` (see `config/cable.yml`), and `POSTGRES_HOST`, `POSTGRES_USER`, `POSTGRES_PASSWORD` (see `config/database.yml`)
 + bin/dev to start rails server, precompile CSS and JS
 + Visit http://localhost:3000
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV.fetch("REDIS_URL") { "redis://redis:6379/1" } %>
 
 test:
   adapter: test

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,9 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: <%= ENV.fetch('POSTGRES_HOST') { 'postgres' } %>
+  user: <%= ENV.fetch('POSTGRES_USER') { 'postgres' }  %>
+  password: <%= ENV.fetch('POSTGRES_PASSWORD') { 'postgres' } %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.6"
+
+# `docker-compose build` to build the containers.
+# `docker-compose up` to run them
+
+services:
+  web:
+    tty: true
+    stdin_open: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash -c "rm -f tmp/pids/server.pid && /app/bin/dev"
+    restart: always
+    volumes:
+      - ".:/app"
+      - "/app/node_modules"
+    ports:
+      - "3000:3000"
+    links:
+      - "postgres"
+      - "redis"
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+  postgres:
+    image: postgres:latest
+    restart: always
+    volumes:
+      - 'postgres:/var/lib/postgresql/data'
+    ports:
+      - "5432"
+  redis:
+    image: redis:latest
+    restart: always
+    volumes:
+      - "redis:/data"
+    ports:
+      - "6379"
+
+volumes:
+  redis:
+  postgres:


### PR DESCRIPTION
This dockerizes the application. After cloning the repo, to run the app, one need only to 
1. `docker-compose build`
2. `docker-compose up`

Also updated the cable.yml and database.yml to work with docker-compose orchestration out of the box. The trade off is that it will break local development unless one sets the required envars for 
`REDIS_URL`, `POSTGRES_HOST`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.